### PR TITLE
fix a few obsolete item references across a handful of mods

### DIFF
--- a/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/GourmandsGraces/grocery1.json
+++ b/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/GourmandsGraces/grocery1.json
@@ -21,7 +21,7 @@
       [ "sandwich_pb", 35 ],
       [ "fish_sandwich", 20 ],
       [ "sandwich_t", 50 ],
-      [ "frozen_burrito", 30 ],
+      [ "junk_burrito", 30 ],
       [ "taco", 40 ],
       [ "insta_salad", 60 ],
       [ "yoghurt", 50 ],
@@ -117,7 +117,7 @@
       [ "frozen_dinner", 80 ],
       [ "pizza_veggy", 50 ],
       [ "pizza_meat", 50 ],
-      [ "frozen_burrito", 50 ]
+      [ "junk_burrito", 50 ]
     ]
   },
   {

--- a/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/GourmandsGraces/pizza_parlor.json
+++ b/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/GourmandsGraces/pizza_parlor.json
@@ -3,8 +3,7 @@
     "id": "pizza_display",
     "type": "item_group",
     "items": [
-      [ "pizza_human", 2 ],
-      [ "pizza_meat", 48 ],
+      [ "pizza_meat", 50 ],
       [ "pizza_veggy", 50 ]
     ]
   },

--- a/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/GourmandsGraces/restaurant.json
+++ b/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/GourmandsGraces/restaurant.json
@@ -78,8 +78,6 @@
     "items": [
       [ "vinegar", 20 ],
       [ "jam_fruit", 5 ],
-      [ "jam_strawberries", 5 ],
-      [ "jam_blueberries", 5 ],
       [ "bread", 17 ],
       [ "meat", 20 ],
       [ "cornbread", 7 ],

--- a/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/Tolerate_This/recipe_food.json
+++ b/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/Tolerate_This/recipe_food.json
@@ -201,7 +201,7 @@
     "qualities": [ { "id": "COOK", "level": 3 }, { "id": "BOIL", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 5, "LIST" ] ] ],
     "components": [
-      [ [ "hickory_nut_unshelled", 4 ] ],
+      [ [ "hickory_nut", 4 ] ],
       [ [ "con_milk", 1 ] ],
       [
         [ "honeycomb", 1 ],

--- a/Kenan-BrightNights-Structured-Modpack/Medium-Maintenance-Small-Mods/CerealMod/grocery1.json
+++ b/Kenan-BrightNights-Structured-Modpack/Medium-Maintenance-Small-Mods/CerealMod/grocery1.json
@@ -21,7 +21,7 @@
       [ "sandwich_pb", 35 ],
       [ "fish_sandwich", 20 ],
       [ "sandwich_t", 50 ],
-      [ "frozen_burrito", 30 ],
+      [ "junk_burrito", 30 ],
       [ "taco", 40 ],
       [ "insta_salad", 60 ],
       [ "yoghurt", 50 ],
@@ -123,7 +123,7 @@
       [ "frozen_dinner", 80 ],
       [ "pizza_veggy", 50 ],
       [ "pizza_meat", 50 ],
-      [ "frozen_burrito", 50 ]
+      [ "junk_burrito", 50 ]
     ]
   },
   {


### PR DESCRIPTION
I noticed that a few of the mods in the pack that I was using were throwing errors for invalid item templates. It wasn't breaking the save, but it was annoying me. These items appear to have been removed/reworked in the base game, so I updated them to reflect that. Oddly enough, some of the items seem to have been removed years ago, so I'm not sure why they only started causing problems for me recently.

Errors on loading a save prior to changes:
![image](https://github.com/user-attachments/assets/3b7a9ed2-b7d3-49a6-8157-0a0c003ed7d6) 
![image](https://github.com/user-attachments/assets/172c00cc-f09e-4634-aa42-694f4491088a)
![image](https://github.com/user-attachments/assets/522340c1-ae4a-435e-8ff4-3d56862463c4)
![image](https://github.com/user-attachments/assets/cc3d3980-f168-493c-a629-c1d5cdeed7a3)
![image](https://github.com/user-attachments/assets/308790f0-1ac8-4cde-a3af-ef22a01094a6)
![image](https://github.com/user-attachments/assets/c78773e7-e602-4775-bd6b-e9809b780c27)

Testing:
After making the changes and moving them to my installed mod folder, the messages no longer appear when loading my game.