### PR TITLE
animatronics: reduce spawns by 13.33x (from 200 to 15)

### DIFF
--- a/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/Animatronics/regional_overlay.json
+++ b/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/Animatronics/regional_overlay.json
@@ -3,6 +3,6 @@
     "type": "region_overlay",
     "regions": [ "all" ],
     "//": "A list of regions to which this overlay should be applied",
-    "city": { "parks": { "//": "weighted list for park overmap terrains", "bankruptpizzeria": 200 } }
+    "city": { "parks": { "//": "weighted list for park overmap terrains", "bankruptpizzeria": 15 } }
   }
 ]


### PR DESCRIPTION
this may seem like alot, but even with 10x reduced spawns (a value of 20) I had 4 spawn in one large city during testing. Not common that many spawn in one city, but I think this should be a reasonable number. At a value of 10, only one spawned in like 6 overmaps. because of this, a value of 15 seems like a reasonable amount where I get about 1-2 per large city in my testing.