### PR TITLE
Expansion Tefnut: Make survivor heelys on/off the same material

### DIFF
--- a/Kenan-BrightNights-Structured-Modpack/Unmaintained-Mods/Expansion_Tefnut/items/armor/boots.json
+++ b/Kenan-BrightNights-Structured-Modpack/Unmaintained-Mods/Expansion_Tefnut/items/armor/boots.json
@@ -31,7 +31,7 @@
     "volume": "1500 ml",
     "price": "100 USD",
     "price_postapoc": "12 USD",
-    "material": [ "cotton", "leather" ],
+    "material": [ "kevlar", "leather" ],
     "symbol": "[",
     "looks_like": "sneakers",
     "color": "light_blue",


### PR DESCRIPTION
Currently, turning on a pair of survivor heelys will magically transmute the kevlar into cotton, and turning them off will turn them back. This makes `survivor heelys (on)` much weaker than `survivor heelys (off)`
Now they are both made of the same material.